### PR TITLE
Improve error message for missing Prometheus receiver

### DIFF
--- a/.chloggen/improve-prometheus-receiver-error.yaml
+++ b/.chloggen/improve-prometheus-receiver-error.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Improve the error message when the target allocator is enabled but the Prometheus receiver is not named exactly "prometheus".
+
+# One or more tracking issues related to the change
+issues: [5017]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When only named instances such as "prometheus/otelcol" are present, the error now lists them and explains that a receiver named exactly "prometheus" is required.

--- a/internal/manifests/targetallocator/adapters/config_to_prom_config.go
+++ b/internal/manifests/targetallocator/adapters/config_to_prom_config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector/adapters"
@@ -81,6 +82,23 @@ func GetScrapeConfigsFromPromConfig(promReceiverConfig map[any]any) ([]map[strin
 	return scrapeConfigMaps, nil
 }
 
+// namedPrometheusReceivers returns the names of any "prometheus/<name>" receivers
+// present in the receivers config, sorted for stable output.
+func namedPrometheusReceivers(receivers map[any]any) []string {
+	var named []string
+	for key := range receivers {
+		keyStr, ok := key.(string)
+		if !ok {
+			continue
+		}
+		if strings.HasPrefix(keyStr, "prometheus/") {
+			named = append(named, keyStr)
+		}
+	}
+	slices.Sort(named)
+	return named
+}
+
 // ConfigToPromConfig converts the incoming configuration object into the Prometheus receiver config.
 func ConfigToPromConfig(cfg string) (map[any]any, error) {
 	config, err := adapters.ConfigFromString(cfg)
@@ -100,6 +118,9 @@ func ConfigToPromConfig(cfg string) (map[any]any, error) {
 
 	prometheusProperty, ok := receivers["prometheus"]
 	if !ok {
+		if named := namedPrometheusReceivers(receivers); len(named) > 0 {
+			return nil, fmt.Errorf("the target allocator requires a receiver named exactly \"prometheus\", but only named instances were found: %s; rename one of them to \"prometheus\"", strings.Join(named, ", "))
+		}
 		return nil, errorNoComponent("prometheus")
 	}
 

--- a/internal/manifests/targetallocator/adapters/config_to_prom_config_test.go
+++ b/internal/manifests/targetallocator/adapters/config_to_prom_config_test.go
@@ -106,6 +106,24 @@ func TestExtractPromConfigFromNullConfig(t *testing.T) {
 	assert.True(t, reflect.ValueOf(promConfig).IsNil())
 }
 
+func TestExtractPromConfigFromNamedPrometheusReceivers(t *testing.T) {
+	configStr := `receivers:
+  prometheus/otelcol:
+    config:
+      scrape_configs: []
+  prometheus/loki:
+    config:
+      scrape_configs: []
+`
+
+	// test
+	promConfig, err := ta.ConfigToPromConfig(configStr)
+	assert.EqualError(t, err, `the target allocator requires a receiver named exactly "prometheus", but only named instances were found: prometheus/loki, prometheus/otelcol; rename one of them to "prometheus"`)
+
+	// verify
+	assert.True(t, reflect.ValueOf(promConfig).IsNil())
+}
+
 func TestUnescapeDollarSignsInPromConfig(t *testing.T) {
 	testCases := []struct {
 		description string


### PR DESCRIPTION
**Description:**

Improved the error message when the target allocator is enabled but the Prometheus receiver is not named exactly "prometheus". When only named instances (e.g., "prometheus/otelcol", "prometheus/loki") are present, the error now lists them and explains that a receiver named exactly "prometheus" is required.

This change adds a new helper function `namedPrometheusReceivers()` that identifies and sorts any named Prometheus receivers, then provides a more helpful error message that guides users toward the solution.

**Link to tracking Issue(s):**

- Resolves: #5017

**Testing:**

Added unit test `TestExtractPromConfigFromNamedPrometheusReceivers` that verifies the improved error message is returned when only named Prometheus receivers are present. The test confirms the error message lists the found receivers and explains the requirement for a receiver named exactly "prometheus".

**Documentation:**

A changelog entry was added documenting this enhancement to the target allocator error messaging.

https://claude.ai/code/session_01Cct38pkkotdCQKaPrqoFmb