### PR TITLE
[chore] Gate Docker Hub publishing on secret presence

### DIFF
--- a/.github/workflows/publish-autoinstrumentation-dotnet.yaml
+++ b/.github/workflows/publish-autoinstrumentation-dotnet.yaml
@@ -27,6 +27,8 @@ jobs:
       attestations: write
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -39,7 +41,7 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
-            otel/autoinstrumentation-dotnet
+            ${{ secrets.DOCKER_USERNAME != '' && 'otel/autoinstrumentation-dotnet' || '' }}
             ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/autoinstrumentation-dotnet
           tags: |
             type=match,pattern=v(.*),group=1,value=v${{ env.VERSION }}
@@ -52,7 +54,7 @@ jobs:
 
       - name: Log into Docker.io
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && env.DOCKER_USERNAME != '' }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/publish-autoinstrumentation-java.yaml
+++ b/.github/workflows/publish-autoinstrumentation-java.yaml
@@ -27,6 +27,8 @@ jobs:
       attestations: write
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -39,7 +41,7 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
-            otel/autoinstrumentation-java
+            ${{ secrets.DOCKER_USERNAME != '' && 'otel/autoinstrumentation-java' || '' }}
             ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/autoinstrumentation-java
           tags: |
             type=match,pattern=v(.*),group=1,value=v${{ env.VERSION }}
@@ -53,7 +55,7 @@ jobs:
 
       - name: Log into Docker.io
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && env.DOCKER_USERNAME != '' }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/publish-autoinstrumentation-nodejs.yaml
+++ b/.github/workflows/publish-autoinstrumentation-nodejs.yaml
@@ -27,6 +27,8 @@ jobs:
       attestations: write
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -39,7 +41,7 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
-            otel/autoinstrumentation-nodejs
+            ${{ secrets.DOCKER_USERNAME != '' && 'otel/autoinstrumentation-nodejs' || '' }}
             ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/autoinstrumentation-nodejs
           tags: |
             type=match,pattern=v(.*),group=1,value=v${{ env.VERSION }}
@@ -52,7 +54,7 @@ jobs:
 
       - name: Log into Docker.io
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && env.DOCKER_USERNAME != '' }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/publish-autoinstrumentation-python.yaml
+++ b/.github/workflows/publish-autoinstrumentation-python.yaml
@@ -27,6 +27,8 @@ jobs:
       attestations: write
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -39,7 +41,7 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
-            otel/autoinstrumentation-python
+            ${{ secrets.DOCKER_USERNAME != '' && 'otel/autoinstrumentation-python' || '' }}
             ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/autoinstrumentation-python
           tags: |
             type=match,pattern=v(.*),group=1,value=v${{ env.VERSION }}
@@ -52,7 +54,7 @@ jobs:
 
       - name: Log into Docker.io
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && env.DOCKER_USERNAME != '' }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -26,6 +26,8 @@ jobs:
     outputs:
       digest: ${{ steps.build.outputs.digest }}
       image: ${{ steps.release-image.outputs.image }}
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -72,7 +74,7 @@ jobs:
         with:
           images: |
             ${{ env.GHCR_IMAGE }}
-            ${{ env.DOCKERHUB_IMAGE }}
+            ${{ secrets.DOCKER_USERNAME != '' && env.DOCKERHUB_IMAGE || '' }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -91,7 +93,7 @@ jobs:
 
       - name: Log into Docker.io
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && env.DOCKER_USERNAME != '' }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -124,4 +126,6 @@ jobs:
           UPLOAD: ${{ startsWith(github.ref, 'refs/tags/v') && 'true' || 'false' }}
         run: |
           make cosign-sign IMAGE="${GHCR_IMAGE}" DIGEST="${DIGEST}" UPLOAD="${UPLOAD}"
-          make cosign-sign IMAGE="${DOCKERHUB_IMAGE}" DIGEST="${DIGEST}" UPLOAD="${UPLOAD}"
+          if [ -n "${DOCKER_USERNAME}" ]; then
+            make cosign-sign IMAGE="${DOCKERHUB_IMAGE}" DIGEST="${DIGEST}" UPLOAD="${UPLOAD}"
+          fi

--- a/.github/workflows/publish-must-gather.yaml
+++ b/.github/workflows/publish-must-gather.yaml
@@ -21,6 +21,8 @@ jobs:
       id-token: write
     name: Publish must-gather container image
     runs-on: ubuntu-latest
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -59,7 +61,7 @@ jobs:
 
       - name: Log into Docker.io
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && env.DOCKER_USERNAME != '' }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/publish-operator-bundle.yaml
+++ b/.github/workflows/publish-operator-bundle.yaml
@@ -21,6 +21,8 @@ jobs:
       attestations: write
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -30,7 +32,7 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
-            otel/opentelemetry-operator-bundle
+            ${{ secrets.DOCKER_USERNAME != '' && 'otel/opentelemetry-operator-bundle' || '' }}
             ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/operator-bundle
           tags: |
             type=semver,pattern={{version}}
@@ -46,7 +48,7 @@ jobs:
 
       - name: Log into Docker.io
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && env.DOCKER_USERNAME != '' }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/publish-operator-opamp-bridge.yaml
+++ b/.github/workflows/publish-operator-opamp-bridge.yaml
@@ -24,6 +24,8 @@ jobs:
       attestations: write
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -45,7 +47,7 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
-            otel/operator-opamp-bridge
+            ${{ secrets.DOCKER_USERNAME != '' && 'otel/operator-opamp-bridge' || '' }}
             ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/operator-opamp-bridge
           tags: |
             type=semver,pattern={{version}}
@@ -61,7 +63,7 @@ jobs:
 
       - name: Log into Docker.io
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && env.DOCKER_USERNAME != '' }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/publish-target-allocator.yaml
+++ b/.github/workflows/publish-target-allocator.yaml
@@ -24,6 +24,8 @@ jobs:
       attestations: write
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -45,7 +47,7 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
-            otel/target-allocator
+            ${{ secrets.DOCKER_USERNAME != '' && 'otel/target-allocator' || '' }}
             ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/target-allocator
           tags: |
             type=semver,pattern={{version}}
@@ -61,7 +63,7 @@ jobs:
 
       - name: Log into Docker.io
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && env.DOCKER_USERNAME != '' }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
## Summary

Makes the image-publish workflows succeed in forks that don't have Docker Hub credentials, without changing upstream behavior.

In each `publish-*` workflow the Docker Hub bits are now gated on the `DOCKER_USERNAME` secret being set:
- the `otel/*` image is dropped from the `docker/metadata-action` image list when the secret is absent (`${{ secrets.DOCKER_USERNAME != '' && 'otel/...' || '' }}`);
- the **Log into Docker.io** step is skipped (the `secrets` context isn't available in `if:`, so the secret is mapped to a job-level `DOCKER_USERNAME` env var and the step checks `env.DOCKER_USERNAME != ''`);
- in `publish-images.yaml`, the Docker Hub `cosign-sign` call is shell-guarded.

When the secret is set (i.e. upstream), the `otel/*` image, the Docker Hub login, and signing all run exactly as before — so this is a no-op for `open-telemetry/opentelemetry-operator`.

GHCR publishing is unaffected and continues to run via `GITHUB_TOKEN`.

### Files
- `publish-images.yaml` (image list + login + signing)
- `publish-target-allocator.yaml`, `publish-operator-opamp-bridge.yaml`, `publish-operator-bundle.yaml` (image list + login)
- `publish-autoinstrumentation-{java,nodejs,python,dotnet}.yaml` (image list + login)
- `publish-must-gather.yaml` (login only — it has no `otel/*` image)

## Test plan
- [ ] On a fork without `DOCKER_USERNAME`/`DOCKER_PASSWORD`, a push to `main` runs the publish workflows without failing at the Docker.io login step, building/pushing only the GHCR image.
- [ ] On `open-telemetry/opentelemetry-operator` (secret present), the rendered image list, login, and signing are identical to today.

https://claude.ai/code/session_01Jnmzsb2aZEW3TXnxH6VhpA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jnmzsb2aZEW3TXnxH6VhpA)_