### PR TITLE
[chore] Forward CODECOV_TOKEN into the reusable e2e workflow

### DIFF
--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -16,6 +16,8 @@ jobs:
     uses: ./.github/workflows/e2e-reusable.yaml
     with:
       collector-image: "otel/opentelemetry-collector-contrib-dev:latest"
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   retry-on-failure:
     needs: [run-e2e-tests]
@@ -23,6 +25,8 @@ jobs:
     uses: ./.github/workflows/e2e-reusable.yaml
     with:
       collector-image: "otel/opentelemetry-collector-contrib-dev:latest"
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   create-issue-on-failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-reusable.yaml
+++ b/.github/workflows/e2e-reusable.yaml
@@ -8,6 +8,10 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      CODECOV_TOKEN:
+        description: "Token for uploading test results to Codecov"
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,7 +12,10 @@ permissions:
 jobs:
   run-e2e-tests:
     uses: ./.github/workflows/e2e-reusable.yaml
-  
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+
   # This job is here to ensure the check has the right name we have set in Github's required checks.
   e2e-tests-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
workflow_call does not inherit secrets, so declare CODECOV_TOKEN as an optional secret on the reusable workflow and pass it explicitly from both callers. Fork PRs leave it empty and fall back to tokenless upload.