### PR TITLE
[chore] Aggregate e2e JUnit results into a single Codecov upload

### DIFF
--- a/.github/workflows/e2e-reusable.yaml
+++ b/.github/workflows/e2e-reusable.yaml
@@ -185,11 +185,25 @@ jobs:
       with:
         pattern: e2e-junit-*
         path: .testresults/e2e
+    # download-artifact unpacks each artifact into its own subdirectory as
+    # <report-name>.xml. Codecov's test-results finder only matches basenames
+    # like *junit*.xml/*test*.xml, so flatten every report into a junit-named
+    # file. Prefixing with the artifact directory (which carries the group and
+    # kube version) keeps names unique across matrix cells.
+    - name: Collect JUnit reports for Codecov
+      run: |
+        set -euo pipefail
+        mkdir -p .testresults/junit
+        find .testresults/e2e -name '*.xml' -print0 | while IFS= read -r -d '' f; do
+          artifact=$(basename "$(dirname "$f")")
+          cp "$f" ".testresults/junit/${artifact}-$(basename "$f")"
+        done
+        ls -l .testresults/junit
     - name: Upload test results to Codecov
       uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
       with:
         report_type: test_results
-        directory: .testresults/e2e
+        directory: .testresults/junit
         token: ${{ secrets.CODECOV_TOKEN }}
 
   e2e-tests-check:

--- a/.github/workflows/e2e-reusable.yaml
+++ b/.github/workflows/e2e-reusable.yaml
@@ -165,12 +165,31 @@ jobs:
         name: e2e-junit-${{ matrix.group }}-${{ matrix.kube-version }}
         retention-days: 7
         overwrite: true
+
+  # Aggregate the JUnit results from every matrix job into a single Codecov
+  # upload. Uploading per-matrix-job races Codecov's PR comment, which it posts
+  # as uploads arrive without knowing how many to expect. A single upload that
+  # runs only after all e2e jobs finish yields one complete comment.
+  upload-test-results:
+    runs-on: ubuntu-latest
+    if: always()
+    # Reporting must never gate a merge: a Codecov hiccup shouldn't fail the
+    # workflow and flip the required e2e check red.
+    continue-on-error: true
+    needs: [e2e-tests]
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Download all e2e test results
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        pattern: e2e-junit-*
+        path: .testresults/e2e
     - name: Upload test results to Codecov
-      if: always()
       uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
       with:
         report_type: test_results
-        files: .testresults/e2e/*.xml
+        directory: .testresults/e2e
         token: ${{ secrets.CODECOV_TOKEN }}
 
   e2e-tests-check:


### PR DESCRIPTION
## Problem

Each of the 36 e2e matrix cells (18 groups × 2 Kubernetes versions) uploaded its JUnit results to Codecov independently. Codecov posts/updates the PR comment as uploads arrive, without knowing how many to expect, so the comment landed before the last cells finished — showing incomplete results.

## Fix

Replace the per-cell Codecov upload with a single terminal `upload-test-results` job that:

- `needs: [e2e-tests]`, so it starts only after **every** matrix cell completes (`if: always()`, so failures are still reported);
- downloads all `e2e-junit-*` artifacts (each artifact lands in its own subdirectory, so same-named reports from different Kubernetes versions don't collide);
- performs a **single** Codecov upload via `report_type: test_results` over the aggregated directory.

One upload after everything is done yields one complete comment. This is robust to matrix changes — no hardcoded build count to maintain (unlike `codecov.yml`'s `after_n_builds`).

The job is marked `continue-on-error: true` so a Codecov/download hiccup can never fail the reusable workflow and flip the required e2e check red — reporting must never gate a merge.

## Tradeoff

A single aggregated upload means we no longer set a per-cell Codecov `flag`, so the Kubernetes version is no longer attached as upload metadata. The failed-test list and failure snippets in the comment are unaffected; this only blurs which Kubernetes version a failure came from. Surfacing *which test* failed and *why* — the actual goal — is preserved.

## Setup still required

This depends on the Codecov GitHub App being installed on the repo and a `CODECOV_TOKEN` secret for non-fork runs (fork PRs fall back to tokenless upload). Those are unchanged from the previous PR.

https://claude.ai/code/session_0133JaXgVW57ac2ovopZYuRT

---
_Generated by [Claude Code](https://claude.ai/code/session_0133JaXgVW57ac2ovopZYuRT)_