### PR TITLE
test: intentionally break e2e-pdb assertion to verify Codecov comment (DO NOT MERGE)

### DIFF
--- a/tests/e2e-pdb/pdb/00-assert.yaml
+++ b/tests/e2e-pdb/pdb/00-assert.yaml
@@ -6,4 +6,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: opentelemetry-collector
-  maxUnavailable: 1
+  maxUnavailable: 99


### PR DESCRIPTION
## Purpose

Verify that Codecov posts a Test Analytics PR comment when there are **failing tests** in the uploaded JUnit reports. PR #142 had all tests passing and produced no Codecov comment — this PR intentionally breaks one assertion to test the hypothesis that the comment is suppressed (or otherwise gated) when there are no failures.

## Change

Flips the expected `maxUnavailable` value in `tests/e2e-pdb/pdb/00-assert.yaml` from `1` to `99`. The operator generates a PDB with `maxUnavailable: 1` by default, so the chainsaw assertion will fail on both k8s 1.25 and 1.35 in the `e2e-pdb` matrix group.

Expected outcome: two e2e matrix cells go red, the upload-test-results job still uploads the JUnit reports to Codecov, and (if our hypothesis is right) a Codecov comment appears listing the failing `pdb` test with its assertion error.

**Do not merge.**

https://claude.ai/code/session_0133JaXgVW57ac2ovopZYuRT

---
_Generated by [Claude Code](https://claude.ai/code/session_0133JaXgVW57ac2ovopZYuRT)_