### PR TITLE
Wire up CODECOV_TOKEN secret in Codecov upload steps

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -53,12 +53,14 @@ jobs:
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       continue-on-error: true
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.out
         flags: unittests
     - name: Upload integration-test coverage to Codecov
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       continue-on-error: true
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage-integration.out
         flags: integration
 

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -15,6 +15,8 @@ jobs:
     uses: ./.github/workflows/e2e-reusable.yaml
     with:
       collector-image: "otel/opentelemetry-collector-contrib-dev:latest"
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   retry-on-failure:
     needs: [run-e2e-tests]
@@ -22,6 +24,8 @@ jobs:
     uses: ./.github/workflows/e2e-reusable.yaml
     with:
       collector-image: "otel/opentelemetry-collector-contrib-dev:latest"
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   create-issue-on-failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-reusable.yaml
+++ b/.github/workflows/e2e-reusable.yaml
@@ -8,6 +8,10 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      CODECOV_TOKEN:
+        description: "Token used to authenticate uploads to Codecov"
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -202,6 +206,7 @@ jobs:
     - name: Upload test results to Codecov
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         report_type: test_results
         directory: .testresults/junit
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   run-e2e-tests:
     uses: ./.github/workflows/e2e-reusable.yaml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   # This job is here to ensure the check has the right name we have set in Github's required checks.
   e2e-tests-check:


### PR DESCRIPTION
Pass the CODECOV_TOKEN secret to all codecov-action steps so coverage and test-result uploads authenticate against Codecov. The e2e reusable workflow declares the secret via workflow_call and its callers forward it.
