### PR TITLE
[target allocator] Allow configuring hashing labels for consistent-hashing

### DIFF
--- a/.chloggen/ta-consistent-hashing-labels.yaml
+++ b/.chloggen/ta-consistent-hashing-labels.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow configuring the set of target labels used for hashing by the consistent-hashing allocation strategy via `allocation_strategy_config.consistent_hashing.labels`.
+
+# One or more tracking issues related to the change
+issues: [5183]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When set, targets that share the same values for the configured labels are assigned to the same
+  collector. When unset, the target's URL is used, preserving the previous behavior.

--- a/cmd/otel-allocator/internal/allocation/consistent_hashing.go
+++ b/cmd/otel-allocator/internal/allocation/consistent_hashing.go
@@ -5,6 +5,7 @@ package allocation
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/buraksezer/consistent"
 	"github.com/cespare/xxhash/v2"
@@ -13,6 +14,10 @@ import (
 )
 
 const consistentHashingStrategyName = "consistent-hashing"
+
+// labelValueSeparator separates label values in the hash key so that different label sets which would
+// otherwise concatenate to the same string (e.g. ["ab", "c"] vs ["a", "bc"]) produce distinct keys.
+const labelValueSeparator = 0xff
 
 type hasher struct{}
 
@@ -25,9 +30,12 @@ var _ Strategy = &consistentHashingStrategy{}
 type consistentHashingStrategy struct {
 	config           consistent.Config
 	consistentHasher *consistent.Consistent
+	// hashLabels are the target label names whose values are used to place a target on the hash ring.
+	// When empty, the target's URL is used instead.
+	hashLabels []string
 }
 
-func newConsistentHashingStrategy() Strategy {
+func newConsistentHashingStrategy(hashLabels []string) Strategy {
 	config := consistent.Config{
 		PartitionCount:    1061,
 		ReplicationFactor: 5,
@@ -38,6 +46,7 @@ func newConsistentHashingStrategy() Strategy {
 	chStrategy := &consistentHashingStrategy{
 		consistentHasher: consistentHasher,
 		config:           config,
+		hashLabels:       hashLabels,
 	}
 	return chStrategy
 }
@@ -47,14 +56,29 @@ func (*consistentHashingStrategy) GetName() string {
 }
 
 func (s *consistentHashingStrategy) GetCollectorForTarget(collectors map[string]*Collector, item *target.Item) (*Collector, error) {
-	hashKey := item.TargetURL
-	member := s.consistentHasher.LocateKey([]byte(hashKey))
+	member := s.consistentHasher.LocateKey(s.hashKey(item))
 	collectorName := member.String()
 	collector, ok := collectors[collectorName]
 	if !ok {
 		return nil, fmt.Errorf("unknown collector %s", collectorName)
 	}
 	return collector, nil
+}
+
+// hashKey returns the key used to place the target on the hash ring. By default the target's URL is used,
+// which keeps a target on the same collector regardless of label changes. When hashLabels is configured,
+// the values of those labels are used instead, so targets sharing those label values are assigned to the
+// same collector.
+func (s *consistentHashingStrategy) hashKey(item *target.Item) []byte {
+	if len(s.hashLabels) == 0 {
+		return []byte(item.TargetURL)
+	}
+	var sb strings.Builder
+	for _, name := range s.hashLabels {
+		sb.WriteString(item.Labels.Get(name))
+		sb.WriteByte(labelValueSeparator)
+	}
+	return []byte(sb.String())
 }
 
 func (s *consistentHashingStrategy) SetCollectors(collectors map[string]*Collector) {

--- a/cmd/otel-allocator/internal/allocation/consistent_hashing_test.go
+++ b/cmd/otel-allocator/internal/allocation/consistent_hashing_test.go
@@ -6,8 +6,42 @@ package allocation
 import (
 	"testing"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/internal/target"
 )
+
+// TestConsistentHashingByLabels builds the strategy through the factory (exercising the full
+// config -> builder -> constructor path) and verifies that when hashing labels are configured, targets
+// sharing those label values are assigned to the same collector regardless of their URL.
+func TestConsistentHashingByLabels(t *testing.T) {
+	allocator, err := New(consistentHashingStrategyName, logger, WithStrategyConfig(StrategyConfig{
+		ConsistentHashing: ConsistentHashingStrategyConfig{Labels: []string{"shard"}},
+	}))
+	require.NoError(t, err)
+
+	allocator.SetCollectors(MakeNCollectors(10, 0))
+
+	// Two targets share the same "shard" value but differ in URL and in an unrelated label.
+	labelsA := labels.New(labels.Label{Name: "shard", Value: "a"}, labels.Label{Name: "pod", Value: "1"})
+	labelsB := labels.New(labels.Label{Name: "shard", Value: "a"}, labels.Label{Name: "pod", Value: "2"})
+	targetA := target.NewItem("job", "10.0.0.1:8080", labelsA, "", target.HashLabels(labelsA, "job"))
+	targetB := target.NewItem("job", "10.0.0.2:9090", labelsB, "", target.HashLabels(labelsB, "job"))
+
+	allocator.SetTargets([]*target.Item{targetA, targetB})
+
+	items := allocator.TargetItems()
+	itemA, ok := items[targetA.Hash()]
+	require.True(t, ok)
+	itemB, ok := items[targetB.Hash()]
+	require.True(t, ok)
+
+	require.NotEmpty(t, itemA.CollectorName)
+	assert.Equal(t, itemA.CollectorName, itemB.CollectorName,
+		"targets sharing the configured hashing label should be assigned to the same collector regardless of URL")
+}
 
 func TestRelativelyEvenDistribution(t *testing.T) {
 	numCols := 15

--- a/cmd/otel-allocator/internal/allocation/strategy.go
+++ b/cmd/otel-allocator/internal/allocation/strategy.go
@@ -22,9 +22,11 @@ type strategyBuilder func(config StrategyConfig) (Strategy, error)
 // on without creating an initialization cycle.
 func strategyBuilders() map[string]strategyBuilder {
 	return map[string]strategyBuilder{
-		leastWeightedStrategyName:     func(StrategyConfig) (Strategy, error) { return newleastWeightedStrategy(), nil },
-		consistentHashingStrategyName: func(StrategyConfig) (Strategy, error) { return newConsistentHashingStrategy(), nil },
-		perNodeStrategyName:           buildPerNodeStrategy,
+		leastWeightedStrategyName: func(StrategyConfig) (Strategy, error) { return newleastWeightedStrategy(), nil },
+		consistentHashingStrategyName: func(config StrategyConfig) (Strategy, error) {
+			return newConsistentHashingStrategy(config.ConsistentHashing.Labels), nil
+		},
+		perNodeStrategyName: buildPerNodeStrategy,
 	}
 }
 
@@ -63,7 +65,11 @@ type StrategyConfig struct {
 }
 
 // ConsistentHashingStrategyConfig holds the configuration options for the consistent-hashing strategy.
-type ConsistentHashingStrategyConfig struct{}
+type ConsistentHashingStrategyConfig struct {
+	// Labels is the set of target label names whose values are used to place a target on the hash ring.
+	// When empty, the target's URL is used.
+	Labels []string
+}
 
 // LeastWeightedStrategyConfig holds the configuration options for the least-weighted strategy.
 type LeastWeightedStrategyConfig struct{}

--- a/cmd/otel-allocator/internal/config/config.go
+++ b/cmd/otel-allocator/internal/config/config.go
@@ -90,7 +90,12 @@ type AllocationStrategyConfig struct {
 }
 
 // ConsistentHashingStrategyConfig holds the configuration options for the consistent-hashing allocation strategy.
-type ConsistentHashingStrategyConfig struct{}
+type ConsistentHashingStrategyConfig struct {
+	// Labels is the set of target label names whose values are used to place a target on the hash ring.
+	// When empty, the target's URL is used, which keeps a target on the same collector regardless of its
+	// labels. When set, targets sharing the same values for these labels are assigned to the same collector.
+	Labels []string `yaml:"labels,omitempty"`
+}
 
 // LeastWeightedStrategyConfig holds the configuration options for the least-weighted allocation strategy.
 type LeastWeightedStrategyConfig struct{}

--- a/cmd/otel-allocator/internal/config/config_test.go
+++ b/cmd/otel-allocator/internal/config/config_test.go
@@ -981,7 +981,10 @@ config:
     - job_name: prometheus
 allocation_strategy: per-node
 allocation_strategy_config:
-  consistent_hashing: {}
+  consistent_hashing:
+    labels:
+      - namespace
+      - pod
   least_weighted: {}
   per_node:
     fallback_strategy:
@@ -996,6 +999,7 @@ allocation_strategy_config:
 
 	assert.Equal(t, "per-node", cfg.AllocationStrategy)
 	assert.Equal(t, AllocationStrategyConfig{
+		ConsistentHashing: ConsistentHashingStrategyConfig{Labels: []string{"namespace", "pod"}},
 		PerNode: PerNodeStrategyConfig{
 			FallbackStrategy: &FallbackStrategyConfig{Name: "consistent-hashing"},
 		},

--- a/docs/target-allocator/README.md
+++ b/docs/target-allocator/README.md
@@ -65,6 +65,18 @@ targets to the same collectors, but will experience rebalancing when the collect
 
 This is the default.
 
+By default the target's URL is hashed. To instead hash a specific set of target labels — so that targets sharing the
+same values for those labels are assigned to the same collector — configure `labels`:
+
+```yaml
+allocation_strategy: consistent-hashing
+allocation_strategy_config:
+  consistent_hashing:
+    labels:
+      - namespace
+      - pod
+```
+
 #### `least-weighted`
 
 A strategy that simply assigns the target to the collector with the least number of targets. It achieves more stability


### PR DESCRIPTION
## Description

> **Stacked on top of #144** — this PR targets that branch, not `main`. It's a first real consumer of the `allocation_strategy_config` scaffolding introduced there, exercising the per-strategy config + factory/DI mechanism.

Adds a `labels` option to the consistent-hashing strategy's configuration section. When set, the strategy places a target on the hash ring using the **values of the configured labels** instead of the target's URL, so targets that share those label values are assigned to the same collector. When unset, the target's URL is used, preserving the previous behavior.

```yaml
allocation_strategy: consistent-hashing
allocation_strategy_config:
  consistent_hashing:
    labels:
      - namespace
      - pod
```

## How it exercises the scaffolding

Adding this option touched exactly the seams the factory/DI design intended — no interface changes, no impact on the other strategies:

- **Wire config** (`config.ConsistentHashingStrategyConfig`): a previously-empty placeholder gains a `labels` field.
- **Domain config** (`allocation.StrategyConfig`): gains a `ConsistentHashing` section.
- **Builder**: the consistent-hashing builder reads its own config section and **injects** the labels into the constructor.
- **Constructor** (`newConsistentHashingStrategy(hashLabels)`): takes the resolved labels via DI.
- **`main.go`**: bridges the wire config to the domain config.

## Testing

- `TestConsistentHashingByLabels` builds the strategy through the factory (`New` + `WithStrategyConfig`) and verifies that two targets sharing the configured label value are assigned to the same collector regardless of their URL.
- Config-parsing test extended to cover `consistent_hashing.labels`.
- Existing consistent-hashing tests still pass (default URL-based hashing preserved).
- `go build`, `go vet`, the full target-allocator test suite, and `make chlog-validate` all pass.

Part of #5183

https://claude.ai/code/session_017f8v21amG6WPDuqHgmsC4b

---
_Generated by [Claude Code](https://claude.ai/code/session_017f8v21amG6WPDuqHgmsC4b)_